### PR TITLE
Adding hist and trace to the pickle dump

### DIFF
--- a/notebooks/run_hackett_inference.py
+++ b/notebooks/run_hackett_inference.py
@@ -157,4 +157,6 @@ if __name__ == "__main__":
     import gzip
     import pickle
     with gzip.open('data/hackett_advi.pgz', 'wb') as f:
-        pickle.dump(approx, f)
+        pickle.dump({'approx': approx,
+         'hist': hist,
+         'trace': trace}, f)


### PR DESCRIPTION
Can you derive hist and trace from the approx object?  If not, then how does `hackett.ipynb` extract the `trace` and `hist` information without dumping it into a pickle?

The `approx` ADVI object does contain a `hist` attribute, but it is a `Tensor` object that does not contain a `sample()` method.